### PR TITLE
Fix set next hop

### DIFF
--- a/states/afk/templates/routing_policy/eos/statement.j2
+++ b/states/afk/templates/routing_policy/eos/statement.j2
@@ -83,12 +83,6 @@ route-map {{ route_map_name }} {{ ACTION[actions["config"]["policy-result"]] }} 
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-next-hop") %}
-  {# TODO ipv6? #}
-  {% if actions["bgp-actions"]["config"]["set-next-hop"] == "SELF" %}
-  {%   set next_hop = "peer-address" %}
-  {% else %}
-  {%   set next_hop = actions["bgp-actions"]["config"]["set-next-hop"] %}
-  {% endif %}
   set ip next-hop {{ next_hop }}
 {% endif %}
 

--- a/states/afk/templates/routing_policy/eos/statement.j2
+++ b/states/afk/templates/routing_policy/eos/statement.j2
@@ -83,7 +83,11 @@ route-map {{ route_map_name }} {{ ACTION[actions["config"]["policy-result"]] }} 
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-next-hop") %}
-  set ip next-hop {{ next_hop }}
+  {% if ":" in actions["bgp-actions"]["config"]["set-next-hop"] %}
+  set ipv6 next-hop {{ actions["bgp-actions"]["config"]["set-next-hop"] }}
+  {% else %}
+  set ip next-hop {{ actions["bgp-actions"]["config"]["set-next-hop"] }}
+  {% endif %}
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-med") %}

--- a/states/afk/templates/routing_policy/sonic/statement.j2
+++ b/states/afk/templates/routing_policy/sonic/statement.j2
@@ -83,12 +83,6 @@ route-map {{ route_map_name }} {{ ACTION[actions["config"]["policy-result"]] }} 
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-next-hop") %}
-  {# TODO ipv6 #}
-  {% if actions["bgp-actions"]["config"]["set-next-hop"] == "SELF" %}
-  {%   set next_hop = "peer-address" %}
-  {% else %}
-  {%   set next_hop = actions["bgp-actions"]["config"]["set-next-hop"] %}
-  {% endif %}
   set ip next-hop {{ next_hop }}
 {% endif %}
 

--- a/states/afk/templates/routing_policy/sonic/statement.j2
+++ b/states/afk/templates/routing_policy/sonic/statement.j2
@@ -83,7 +83,11 @@ route-map {{ route_map_name }} {{ ACTION[actions["config"]["policy-result"]] }} 
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-next-hop") %}
-  set ip next-hop {{ next_hop }}
+  {% if ":" in actions["bgp-actions"]["config"]["set-next-hop"] %}
+  set ipv6 next-hop {{ actions["bgp-actions"]["config"]["set-next-hop"] }}
+  {% else %}
+  set ip next-hop {{ actions["bgp-actions"]["config"]["set-next-hop"] }}
+  {% endif %}
 {% endif %}
 
 {% if actions["bgp-actions"] and actions["bgp-actions"]["config"].get("set-med") %}


### PR DESCRIPTION
- remove `set next-hop self` not implemented properly in EOS and SONiC (FRR)
- add support `set next-hop <address>` in IPv6 for EOS and SONiC (FRR)