### PR TITLE
ci: dependabot compliant with conventional commit

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: "pip"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+        commit-message:
+            prefix: "build(deps):"
+            prefix-development: "build(deps-dev):"
+            include: "scope"


### PR DESCRIPTION
Make dependabot commit compliant with conventional commit.

Before: `Bump salt from 3004 to 3004.2`
After: `build(deps): bump salt from 3004 to 3004.2`

See [dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)