### PR TITLE
ci: separate lint, test and doc step in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Running checks with Tox
+      - name: Run linters
         run: |
-          tox
+          tox -e lint
+      - name: Run tests
+        run: |
+          tox -e test
+      - name: Build doc
+        run: |
+          tox -e docs
 
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The goal of this commit is to be able to spot issues easier.

Before this commit, all the checks are run at once in the "Running checks with Tox".

With this commit, lint, test and doc building will be in three separate step.