### PR TITLE
test: always install latest minor version of salt 3004

### DIFF
--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -10,5 +10,5 @@ pyflakes==2.4.0
 pytest
 pytest-benchmark
 pytest-mock
-salt==3004
+salt<3005
 tox


### PR DESCRIPTION
Always install the latest minor of 3004.
It will fix security issues notice.

We should have bumped to 3006 by the end of September.