### PR TITLE
fix(peer-group): peer-as field is removed when null in openconfig

### DIFF
--- a/states/afk/templates/bgp/sonic/peer_group.j2
+++ b/states/afk/templates/bgp/sonic/peer_group.j2
@@ -6,7 +6,7 @@ neighbor {{ peer_group["peer-group-name"] }} local-as {{ peer_group["config"]["l
 no neighbor {{ peer_group["peer-group-name"] }} local-as
 {% endif %}
 
-{% if peer_group["config"]["peer-as"] %}
+{% if deep_get(peer_group, "config", "peer-as") %}
 neighbor {{ peer_group["peer-group-name"] }} remote-as {{ peer_group["config"]["peer-as"] }}
 {% endif %}
 


### PR DESCRIPTION
The open-source version of Data Aggregation API is using Ygot to generate the JSON file.
If peer-as is null, the field disappears from the JSON.

Important note / reminder:
Peer groups are deprecated and are only here to ease internal migration.