### PR TITLE
fix(sonic): increase the delay-timer instead of disabling it

### DIFF
--- a/states/afk/templates/routing_policy/sonic/routing_policy.j2
+++ b/states/afk/templates/routing_policy/sonic/routing_policy.j2
@@ -1,5 +1,5 @@
 {# prevent route-map to be applied immediately (still applied after a clear or BGP update/reset) #}
-bgp route-map delay-timer 0
+bgp route-map delay-timer 300
 !
 {% for community in community_sets %}
 {{ community }}

--- a/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic.txt
+++ b/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic.txt
@@ -1,4 +1,4 @@
-bgp route-map delay-timer 0
+bgp route-map delay-timer 300
 !
 bgp community-list expanded CL-LOCAL permit 65000:100.
 bgp community-list expanded CL-MAIN permit 649..:20000

--- a/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic_existing.txt
+++ b/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic_existing.txt
@@ -1,4 +1,4 @@
-bgp route-map delay-timer 0
+bgp route-map delay-timer 300
 !
 bgp community-list expanded CL-LOCAL permit 65000:100.
 bgp community-list expanded CL-MAIN permit 649..:20000


### PR DESCRIPTION
It should fix an issue in FRR8.2.2 (SONiC 202205).

Before this commit the timer was disabled completely.

We highly suspect that disabling and re-enabling the event driven changes blocks the updates indefinitely when a prefix-list changes.

When putting 300s instead, once this timer expires, the changes are well applied. The default 5s are not respected immediately.

Did not have the issue with FRR7.2.1 (SONiC 201911).