### PR TITLE
Revert "fix(sonic): increase the delay-timer instead of disabling it"

### DIFF
--- a/states/afk/templates/routing_policy/sonic/routing_policy.j2
+++ b/states/afk/templates/routing_policy/sonic/routing_policy.j2
@@ -1,5 +1,5 @@
 {# prevent route-map to be applied immediately (still applied after a clear or BGP update/reset) #}
-bgp route-map delay-timer 300
+bgp route-map delay-timer 0
 !
 {% for community in community_sets %}
 {{ community }}

--- a/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic.txt
+++ b/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic.txt
@@ -1,4 +1,4 @@
-bgp route-map delay-timer 300
+bgp route-map delay-timer 0
 !
 bgp community-list expanded CL-LOCAL permit 65000:100.
 bgp community-list expanded CL-MAIN permit 649..:20000

--- a/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic_existing.txt
+++ b/tests/states/openconfig_routing_policy/data/integration_tests/expected_result_sonic_existing.txt
@@ -1,4 +1,4 @@
-bgp route-map delay-timer 300
+bgp route-map delay-timer 0
 !
 bgp community-list expanded CL-LOCAL permit 65000:100.
 bgp community-list expanded CL-MAIN permit 649..:20000


### PR DESCRIPTION
Reverts criteo/afk-saltstack#19

causing bug at least on 201911