### PR TITLE
fix(bgp): clear soft all neighbors when changes

### DIFF
--- a/_modules/criteo_bgp.py
+++ b/_modules/criteo_bgp.py
@@ -4,6 +4,7 @@
 :maturity:   new
 :platform:   SONiC, Arista EOS, Juniper JunOS
 """
+
 import json
 from ipaddress import ip_address, ip_interface
 

--- a/_states/afk_bgp.py
+++ b/_states/afk_bgp.py
@@ -1,0 +1,31 @@
+"""States modules for AFK."""
+
+import time
+
+
+def _get_os():
+    return __salt__["grains.get"]("nos", __salt__["grains.get"]("os"))
+
+
+def clear_soft_all(name):
+    """Execute a clear soft on all neighbors on all directions."""
+    nos = _get_os()
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+
+    if nos == "sonic":
+        time.sleep(5)  # we wait for bgp route-map delay-timer (which is set to 5 seconds)
+        res = __salt__["cmd.run"]("vtysh -c 'clear bgp * soft'")
+        ret["changes"]["executed"] = "vtysh -c 'clear bgp * soft"
+    elif nos == "junos":
+        res = __salt__["net.cli"]("clear bgp neighbor soft all")
+        ret["changes"]["executed"] = "clear bgp neighbor soft all"
+    elif nos == "eos":
+        res = __salt__["net.cli"]("clear bgp soft")
+        ret["changes"]["executed"] = "clear bgp soft"
+    else:
+        raise NotImplementedError("Network OS not supported")
+
+    ret["result"] = __context__["retcode"] == 0
+    ret["comment"] = res
+
+    return ret

--- a/_states/openconfig_routing_policy.py
+++ b/_states/openconfig_routing_policy.py
@@ -4,6 +4,7 @@
 :maturity:   new
 :platform:   SONiC, Arista EOS, Juniper JunOS
 """
+
 import logging
 import re
 
@@ -470,7 +471,7 @@ def apply(name, openconfig_routing_policy=None, openconfig_bgp=None, saltenv="ba
     :param openconfig_bgp: BGP configuration in JSON in openconfig (bgp)
     :param saltenv: salt environment
     """
-    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+    ret = {"name": name, "result": False, "changes": {}, "comment": []}
 
     # generate command to apply on the device using the templates
     log.debug("%s starting", name)
@@ -486,7 +487,6 @@ def apply(name, openconfig_routing_policy=None, openconfig_bgp=None, saltenv="ba
         # only return generated commands/config during tests
         # there is an ongoing bug with napalm making dry-run really applying the config sometimes
         if __opts__["test"]:
-            ret["changes"] = {"gen": config}
             ret["result"] = None
             return ret
 
@@ -505,8 +505,10 @@ def apply(name, openconfig_routing_policy=None, openconfig_bgp=None, saltenv="ba
         )
         res["diff"] = res["changes"]
 
-    ret["comment"] = res["comment"]
-    ret["changes"] = {"diff": res["diff"], "loaded": config}
+    ret["comment"].append("- loaded:\n{}".format(config))
+    ret["comment"].append(res["comment"])
+    if res["diff"]:
+        ret["changes"] = {"diff": res["diff"]}
     ret["result"] = res["result"]
 
     return ret

--- a/_utils/frr_detect_diff.py
+++ b/_utils/frr_detect_diff.py
@@ -13,6 +13,7 @@ This module will be removed when FRR developers will finish the development of N
 :maturity:   new
 :platform:   SONiC,FRR
 """
+
 import re
 from collections import defaultdict
 

--- a/states/afk/init.sls
+++ b/states/afk/init.sls
@@ -10,3 +10,9 @@ bgp_sessions:
         - require:
             - openconfig_routing_policy: route_policies
         - saltenv: {{ saltenv }}
+
+clear_bgp_soft:
+    afk_bgp.clear_soft_all:
+        - onchanges:
+            - openconfig_bgp: bgp_sessions
+            - openconfig_routing_policy: route_policies


### PR DESCRIPTION
Changing route-policies or some BGP parameters often require to clear soft the neighbors.

Considering that identifying the concerned neighbors can be a bit tricky, and clear soft is basically harmless nowadays, we simply clear soft all neighbors when we detect a change.

In the future, if needed, we could clear soft only relevant neighbors.