### PR TITLE
fix: net.cli does not set retcode in context

### DIFF
--- a/_states/afk_bgp.py
+++ b/_states/afk_bgp.py
@@ -16,16 +16,18 @@ def clear_soft_all(name):
         time.sleep(5)  # we wait for bgp route-map delay-timer (which is set to 5 seconds)
         res = __salt__["cmd.run"]("vtysh -c 'clear bgp * soft'")
         ret["changes"]["executed"] = "vtysh -c 'clear bgp * soft"
+        ret["result"] = __context__["retcode"] == 0
     elif nos == "junos":
         res = __salt__["net.cli"]("clear bgp neighbor soft all")
         ret["changes"]["executed"] = "clear bgp neighbor soft all"
+        ret["result"] = res["result"]
     elif nos == "eos":
         res = __salt__["net.cli"]("clear bgp soft")
         ret["changes"]["executed"] = "clear bgp soft"
+        ret["result"] = res["result"]
     else:
         raise NotImplementedError("Network OS not supported")
 
-    ret["result"] = __context__["retcode"] == 0
     ret["comment"] = res
 
     return ret


### PR DESCRIPTION
net.cli does not set `__context__["retcode"]`, but returns `result` instead.