### PR TITLE
fix(rp): prefix/community list changes not applied

### DIFF
--- a/_states/openconfig_routing_policy.py
+++ b/_states/openconfig_routing_policy.py
@@ -448,9 +448,18 @@ def _generate_routing_policy_config(openconfig_routing_policy, openconfig_bgp, _
         "policy_definitions": policy_definitions,
     }
 
+    suffix = ""
     nos = _get_os()
+    if nos == "sonic":
+        version = __salt__["grains.get"]("sonic_build_version")
+
+        frr822 = "202205" in version or "202211" in version
+        workaround_flag = __salt__["pillar.get"]("frr822_workaround_flag", "False") == "True"
+        if frr822 and workaround_flag:
+            suffix = "_8_2_2"
+
     config = _apply_template(
-        "salt://states/afk/templates/routing_policy/{}/routing_policy.j2".format(nos),
+        "salt://states/afk/templates/routing_policy/{}/routing_policy{}.j2".format(nos, suffix),
         context,
         saltenv,
     )

--- a/pylama.ini
+++ b/pylama.ini
@@ -14,7 +14,7 @@ skip={toxworkdir}/*,build/*,.tox/*,env/*,.env/*,venv/*,.venv/*,setup.py,docs/*
 linters=pylint,pycodestyle,pydocstyle
 
 [pylama:pylint]
-ignore=W0511,C0103,R0913,W1510,W0603,C0209
+ignore=W0511,C0103,R0913,W1510,W0603,C0209,R0914,R0917
 
 [pylama:pydocstyle]
 ignore=D203,D213,D407,D413

--- a/states/afk/templates/routing_policy/sonic/routing_policy_frr_8_2_2.j2
+++ b/states/afk/templates/routing_policy/sonic/routing_policy_frr_8_2_2.j2
@@ -1,0 +1,21 @@
+{# in FRR 8.2.2 (SONiC 202205 and 202211), a bug appeared where prefix-list changes were never applied. #}
+{# The workaround is to apply this outside of bgp route-map delay-timer changes. #}
+{# It has been fixed starting FRR 8.4.4 (SONiC >= 202311) #}
+{# fixed by: https://github.com/FRRouting/frr/pull/13124 #}
+{# issue coming from: https://github.com/FRRouting/frr/issues/13125 #}
+{% for community in community_sets %}
+{{ community }}
+{% endfor %}
+!
+{% for prefix in prefix_sets %}
+{{ prefix | trim }}
+{% endfor %}
+!
+{# prevent route-map to be applied immediately (still applied after a clear or BGP update/reset) #}
+bgp route-map delay-timer 0
+!
+{% for policy_definitions in policy_definitions %}
+{{ policy_definitions }}
+!
+{% endfor %}
+no bgp route-map delay-timer

--- a/tests/states/openconfig_routing_policy/integration_tests/test_openconfig_routing_policy_sonic_integration.py
+++ b/tests/states/openconfig_routing_policy/integration_tests/test_openconfig_routing_policy_sonic_integration.py
@@ -49,6 +49,8 @@ def _apply_common_mock(mocker):
         "file.apply_template_on_contents": _mock_apply_template_on_contents,
         "cp.get_file_str": _mock_get_file_str,
         "sonic.get_bgp_config": lambda *_: (""),
+        "grains.get": lambda name, *_: "201911" if name == "sonic_build_version" else None,
+        "pillar.get": lambda name, *_: "False" if name == "frr822_workaround_flag" else None,
     }
     STATE_MOD.__utils__ = {
         "frr_detect_diff.get_objects": frr_detect_diff.get_objects,


### PR DESCRIPTION
Only affects FRR 8.2.2, e.g. SONiC 202205 and 202211.

The issue comes from a behavior change with prefix-list and bgp route-map-delay timer.

It has been fixed starting FRR 8.4.4.