### PR TITLE
fix(bgp): delayopen timer not in SONiC 201911

### DIFF
--- a/_states/openconfig_bgp.py
+++ b/_states/openconfig_bgp.py
@@ -232,6 +232,7 @@ def _generate_neighbor_part(
         "result", {}
     )
     context = {
+        "version": __salt__["grains.get"]("version"),
         "neighbor": neighbor,
         "global_as": global_as,
         "vrf": default_vrf,  # TODO: add VRF support

--- a/_states/openconfig_bgp.py
+++ b/_states/openconfig_bgp.py
@@ -231,8 +231,15 @@ def _generate_neighbor_part(
     current_bgp_config = __salt__["criteo_bgp.get_neighbors"](dict_per_address=True).get(
         "result", {}
     )
+
+    nos = _get_os()
+    timer_delayopen_supported = True
+    if nos == "sonic" and "201911" in __salt__["grains.get"]("sonic_build_version"):
+        # delayopen timer is disabled for 201911 as not supported by FRR version
+        timer_delayopen_supported = False
+
     context = {
-        "version": __salt__["grains.get"]("version"),
+        "timer_delayopen_supported": timer_delayopen_supported,
         "neighbor": neighbor,
         "global_as": global_as,
         "vrf": default_vrf,  # TODO: add VRF support

--- a/states/afk/templates/bgp/sonic/neighbor.j2
+++ b/states/afk/templates/bgp/sonic/neighbor.j2
@@ -39,7 +39,7 @@ neighbor {{ neighbor["neighbor-address"] }} password {{ neighbor["config"]["auth
 no neighbor {{ neighbor["neighbor-address"] }} password
 {% endif %}
 
-{% if version and "201911" in version %}
+{% if timer_delayopen_supported %}
     {% if deep_get(neighbor, "timers", "config", "delay-open-timer") %}
 neighbor {{ neighbor["neighbor-address"] }} timers delayopen {{ neighbor["timers"]["config"]["delay-open-timer"] }}
     {% else %}

--- a/states/afk/templates/bgp/sonic/neighbor.j2
+++ b/states/afk/templates/bgp/sonic/neighbor.j2
@@ -39,10 +39,12 @@ neighbor {{ neighbor["neighbor-address"] }} password {{ neighbor["config"]["auth
 no neighbor {{ neighbor["neighbor-address"] }} password
 {% endif %}
 
-{% if deep_get(neighbor, "timers", "config", "delay-open-timer") %}
+{% if version and "201911" in version %}
+    {% if deep_get(neighbor, "timers", "config", "delay-open-timer") %}
 neighbor {{ neighbor["neighbor-address"] }} timers delayopen {{ neighbor["timers"]["config"]["delay-open-timer"] }}
-{% else %}
+    {% else %}
 no neighbor {{ neighbor["neighbor-address"] }} timers delayopen
+    {% endif %}
 {% endif %}
 
 {% if neighbor["config"]["enabled"] == true %}

--- a/tests/states/openconfig_bgp/mock_helpers.py
+++ b/tests/states/openconfig_bgp/mock_helpers.py
@@ -52,6 +52,9 @@ def _apply_common_mock(mocker, network_os):
         "jinja_filters.deep_get": STATE_UTIL.deep_get,
     }
 
+    if network_os == "sonic":
+        STATE_MOD.__salt__["grains.get"] = lambda name, *_: "202205" if name == "sonic_build_version" else None
+
 
 def salt_bgp_mock(network_os):
     def decorator(func):


### PR DESCRIPTION
`neighbor x.x.x.x timers delayopen` option does not exist in FRR version installed in SONiC 201911