### PR TITLE
fix(bgp): safi not closed

### DIFF
--- a/states/afk/templates/bgp/sonic/bgp.j2
+++ b/states/afk/templates/bgp/sonic/bgp.j2
@@ -22,4 +22,5 @@ router bgp {{ global_as }}
     {% for safi_config in safi %}
         {{ safi_config | indent(width=8, first=False) }}
     {% endfor -%}
+    exit-address-family
 {% endfor -%}

--- a/states/afk/templates/bgp/sonic/global_configuration.j2
+++ b/states/afk/templates/bgp/sonic/global_configuration.j2
@@ -32,18 +32,22 @@ no bgp graceful-restart restart-time
 address-family ipv4 unicast
   maximum-paths {{ ebgp_maximum_paths }}
   maximum-paths ibgp {{ ibgp_maximum_paths }}
+exit-address-family
 !
 address-family ipv6 unicast
   maximum-paths {{ ebgp_maximum_paths }}
   maximum-paths ibgp {{ ibgp_maximum_paths }}
+exit-address-family
 {% else %}
 address-family ipv4 unicast
   no maximum-paths
   no maximum-paths ibgp
+  exit-address-family
 !
 address-family ipv6 unicast
   no maximum-paths
   no maximum-paths ibgp
+exit-address-family
 {% endif %}
 
 {% set aggregates = deep_get(global_safi_configs, "IPV4_UNICAST", "config", "aggregates") %}
@@ -61,6 +65,7 @@ address-family ipv4 unicast
   network {{ prefix }}
     {% endfor %}
   {% endif %}
+exit-address-family
 {% endif %}
 {% set aggregates = deep_get(global_safi_configs, "IPV6_UNICAST", "config", "aggregates") %}
 {% set networks = deep_get(global_safi_configs, "IPV6_UNICAST", "config", "redistributed-networks") %}
@@ -77,4 +82,5 @@ address-family ipv6 unicast
   network {{ prefix }}
     {% endfor %}
   {% endif %}
+exit-address-family
 {% endif %}

--- a/tests/states/openconfig_bgp/data/integration_tests/full_config/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/full_config/expected_result_sonic.txt
@@ -71,6 +71,7 @@ router bgp 65000
         no neighbor 2001:db8::102 activate
         no neighbor 2001:db8::102 soft-reconfiguration inbound
         no neighbor 2001:db8::102 send-community
+    exit-address-family
     !
     address-family ipv6 unicast
         neighbor RA02.01:PG-TOR route-map RM-LAN-IN in
@@ -105,3 +106,4 @@ router bgp 65000
         neighbor 2001:db8::102 activate
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/v4_only/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/v4_only/expected_result_sonic.txt
@@ -27,6 +27,7 @@ router bgp 65000
         neighbor 192.0.2.2 activate
         neighbor 192.0.2.2 soft-reconfiguration inbound
         neighbor 192.0.2.2 send-community
+    exit-address-family
     !
     address-family ipv6 unicast
         no neighbor 192.0.2.1 route-map * in
@@ -41,3 +42,4 @@ router bgp 65000
         no neighbor 192.0.2.2 activate
         no neighbor 192.0.2.2 soft-reconfiguration inbound
         no neighbor 192.0.2.2 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/v6_only/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/v6_only/expected_result_sonic.txt
@@ -27,6 +27,7 @@ router bgp 65000
         no neighbor 2001:db8::102 activate
         no neighbor 2001:db8::102 soft-reconfiguration inbound
         no neighbor 2001:db8::102 send-community
+    exit-address-family
     !
     address-family ipv6 unicast
         neighbor 2001:db8::101 route-map RM-LAN-IN in
@@ -41,3 +42,4 @@ router bgp 65000
         neighbor 2001:db8::102 activate
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/with_extras/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/with_extras/expected_result_sonic.txt
@@ -56,6 +56,7 @@ router bgp 65000
         no neighbor 2001:db8::102 activate
         no neighbor 2001:db8::102 soft-reconfiguration inbound
         no neighbor 2001:db8::102 send-community
+    exit-address-family
     !
     address-family ipv6 unicast
         no neighbor 192.0.2.1 route-map * in
@@ -82,3 +83,4 @@ router bgp 65000
         neighbor 2001:db8::102 activate
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/test_bgp_global/test_openconfig_bgp_global_sonic.py
+++ b/tests/states/openconfig_bgp/test_bgp_global/test_openconfig_bgp_global_sonic.py
@@ -20,10 +20,12 @@ def test__generate_global_configuration_minimal(mocker):
         "address-family ipv4 unicast\n"
         "  no maximum-paths\n"
         "  no maximum-paths ibgp\n"
+        "  exit-address-family\n"
         "!\n"
         "address-family ipv6 unicast\n"
         "  no maximum-paths\n"
-        "  no maximum-paths ibgp"
+        "  no maximum-paths ibgp\n"
+        "exit-address-family"
     )
 
 
@@ -47,10 +49,12 @@ def test__generate_global_configuration_minimal2(mocker):
         "address-family ipv4 unicast\n"
         "  no maximum-paths\n"
         "  no maximum-paths ibgp\n"
+        "  exit-address-family\n"
         "!\n"
         "address-family ipv6 unicast\n"
         "  no maximum-paths\n"
-        "  no maximum-paths ibgp"
+        "  no maximum-paths ibgp\n"
+        "exit-address-family"
     )
 
 
@@ -79,10 +83,12 @@ def test__generate_global_configuration_full(mocker):
         "address-family ipv4 unicast\n"
         "  maximum-paths 128\n"
         "  maximum-paths ibgp 128\n"
+        "exit-address-family\n"
         "!\n"
         "address-family ipv6 unicast\n"
         "  maximum-paths 128\n"
-        "  maximum-paths ibgp 128"
+        "  maximum-paths ibgp 128\n"
+        "exit-address-family"
     )
 
 
@@ -124,13 +130,16 @@ def test__generate_global_configuration_aggregates_and_networks(mocker):
         "address-family ipv4 unicast\n"
         "  maximum-paths 128\n"
         "  maximum-paths ibgp 128\n"
+        "exit-address-family\n"
         "!\n"
         "address-family ipv6 unicast\n"
         "  maximum-paths 128\n"
         "  maximum-paths ibgp 128\n"
+        "exit-address-family\n"
         "!\n"
         "address-family ipv4 unicast\n"
         "  aggregate-address 10.0.8.0/24\n"
         "  network 10.0.8.0/24\n"
-        "  network 10.0.1.0/31"
+        "  network 10.0.1.0/31\n"
+        "exit-address-family"
     )


### PR DESCRIPTION
Before this PR:
Errors when trying to create a peer-group. As it is still in the address-family, frr cannot know if the neighbor command must be applied in the safi or in global.