### PR TITLE
fix(sonic/bgp): missing L2VPN family

### DIFF
--- a/_states/openconfig_bgp.py
+++ b/_states/openconfig_bgp.py
@@ -210,6 +210,10 @@ def _generate_peer_group(peer_group, bgp_distance, saltenv):
     safis_config["IPV6_UNICAST"] = _generate_safi_part(
         "IPV6_UNICAST", safis.get("IPV6_UNICAST", {}), peer_group, SafiAssetType.PEER_GROUP, saltenv
     )
+    if "L2VPN_EVPN" in SAFIS_ALIAS[_get_os()]:
+        safis_config["L2VPN_EVPN"] = _generate_safi_part(
+            "L2VPN_EVPN", safis.get("L2VPN_EVPN", {}), peer_group, SafiAssetType.PEER_GROUP, saltenv
+        )
 
     peer_group_config = _generate_peer_group_part(
         peer_group, prefix_limit_config, bgp_distance, saltenv
@@ -351,6 +355,10 @@ def _generate_neighbor_config(neighbor, global_as, bgp_distance, peer_groups, sa
     safis_config["IPV6_UNICAST"] = _generate_safi_part(
         "IPV6_UNICAST", safis.get("IPV6_UNICAST", {}), neighbor, SafiAssetType.NEIGHBOR, saltenv
     )
+    if "L2VPN_EVPN" in SAFIS_ALIAS[_get_os()]:
+        safis_config["L2VPN_EVPN"] = _generate_safi_part(
+            "L2VPN_EVPN", safis.get("L2VPN_EVPN", {}), neighbor, SafiAssetType.NEIGHBOR, saltenv
+        )
 
     return (neighbor_config, safis_config)
 

--- a/tests/states/openconfig_bgp/data/integration_tests/full_config/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/full_config/expected_result_sonic.txt
@@ -107,3 +107,38 @@ router bgp 65000
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
     exit-address-family
+    !
+    address-family l2vpn evpn
+        neighbor RA02.01:PG-TOR route-map RM-LAN-IN in
+        neighbor RA02.01:PG-TOR route-map RM-LAN-OUT out
+        no neighbor RA02.01:PG-TOR maximum-prefix
+        neighbor RA02.01:PG-TOR send-community
+        neighbor RA02.01:PG-TOR-NO-PEER-AS route-map RM-LAN-IN in
+        neighbor RA02.01:PG-TOR-NO-PEER-AS route-map RM-LAN-OUT out
+        no neighbor RA02.01:PG-TOR-NO-PEER-AS maximum-prefix
+        neighbor RA02.01:PG-TOR-NO-PEER-AS send-community
+        no neighbor 192.0.2.1 route-map * in
+        no neighbor 192.0.2.1 route-map * out
+        no neighbor 192.0.2.1 maximum-prefix
+        no neighbor 192.0.2.1 activate
+        no neighbor 192.0.2.1 soft-reconfiguration inbound
+        no neighbor 192.0.2.1 send-community
+        no neighbor 192.0.2.2 route-map * in
+        no neighbor 192.0.2.2 route-map * out
+        no neighbor 192.0.2.2 maximum-prefix
+        no neighbor 192.0.2.2 activate
+        no neighbor 192.0.2.2 soft-reconfiguration inbound
+        no neighbor 192.0.2.2 send-community
+        no neighbor 2001:db8::101 route-map * in
+        no neighbor 2001:db8::101 route-map * out
+        no neighbor 2001:db8::101 maximum-prefix
+        no neighbor 2001:db8::101 activate
+        no neighbor 2001:db8::101 soft-reconfiguration inbound
+        no neighbor 2001:db8::101 send-community
+        no neighbor 2001:db8::102 route-map * in
+        no neighbor 2001:db8::102 route-map * out
+        no neighbor 2001:db8::102 maximum-prefix
+        no neighbor 2001:db8::102 activate
+        no neighbor 2001:db8::102 soft-reconfiguration inbound
+        no neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/v4_only/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/v4_only/expected_result_sonic.txt
@@ -43,3 +43,18 @@ router bgp 65000
         no neighbor 192.0.2.2 soft-reconfiguration inbound
         no neighbor 192.0.2.2 send-community
     exit-address-family
+    !
+    address-family l2vpn evpn
+        no neighbor 192.0.2.1 route-map * in
+        no neighbor 192.0.2.1 route-map * out
+        no neighbor 192.0.2.1 maximum-prefix
+        no neighbor 192.0.2.1 activate
+        no neighbor 192.0.2.1 soft-reconfiguration inbound
+        no neighbor 192.0.2.1 send-community
+        no neighbor 192.0.2.2 route-map * in
+        no neighbor 192.0.2.2 route-map * out
+        no neighbor 192.0.2.2 maximum-prefix
+        no neighbor 192.0.2.2 activate
+        no neighbor 192.0.2.2 soft-reconfiguration inbound
+        no neighbor 192.0.2.2 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/v6_only/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/v6_only/expected_result_sonic.txt
@@ -43,3 +43,18 @@ router bgp 65000
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
     exit-address-family
+    !
+    address-family l2vpn evpn
+        no neighbor 2001:db8::101 route-map * in
+        no neighbor 2001:db8::101 route-map * out
+        no neighbor 2001:db8::101 maximum-prefix
+        no neighbor 2001:db8::101 activate
+        no neighbor 2001:db8::101 soft-reconfiguration inbound
+        no neighbor 2001:db8::101 send-community
+        no neighbor 2001:db8::102 route-map * in
+        no neighbor 2001:db8::102 route-map * out
+        no neighbor 2001:db8::102 maximum-prefix
+        no neighbor 2001:db8::102 activate
+        no neighbor 2001:db8::102 soft-reconfiguration inbound
+        no neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/data/integration_tests/with_extras/expected_result_sonic.txt
+++ b/tests/states/openconfig_bgp/data/integration_tests/with_extras/expected_result_sonic.txt
@@ -84,3 +84,30 @@ router bgp 65000
         neighbor 2001:db8::102 soft-reconfiguration inbound
         neighbor 2001:db8::102 send-community
     exit-address-family
+    !
+    address-family l2vpn evpn
+        no neighbor 192.0.2.1 route-map * in
+        no neighbor 192.0.2.1 route-map * out
+        no neighbor 192.0.2.1 maximum-prefix
+        no neighbor 192.0.2.1 activate
+        no neighbor 192.0.2.1 soft-reconfiguration inbound
+        no neighbor 192.0.2.1 send-community
+        no neighbor 192.0.2.2 route-map * in
+        no neighbor 192.0.2.2 route-map * out
+        no neighbor 192.0.2.2 maximum-prefix
+        no neighbor 192.0.2.2 activate
+        no neighbor 192.0.2.2 soft-reconfiguration inbound
+        no neighbor 192.0.2.2 send-community
+        no neighbor 2001:db8::101 route-map * in
+        no neighbor 2001:db8::101 route-map * out
+        no neighbor 2001:db8::101 maximum-prefix
+        no neighbor 2001:db8::101 activate
+        no neighbor 2001:db8::101 soft-reconfiguration inbound
+        no neighbor 2001:db8::101 send-community
+        no neighbor 2001:db8::102 route-map * in
+        no neighbor 2001:db8::102 route-map * out
+        no neighbor 2001:db8::102 maximum-prefix
+        no neighbor 2001:db8::102 activate
+        no neighbor 2001:db8::102 soft-reconfiguration inbound
+        no neighbor 2001:db8::102 send-community
+    exit-address-family

--- a/tests/states/openconfig_bgp/neighbors/test_openconfig_neighbors_sonic.py
+++ b/tests/states/openconfig_bgp/neighbors/test_openconfig_neighbors_sonic.py
@@ -70,6 +70,14 @@ def test__generate_neighbor_part__minimal_ipv4_up(mocker):
             "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
             "no neighbor 192.0.2.1 send-community"
         ),
+        "L2VPN_EVPN": (
+            "no neighbor 192.0.2.1 route-map * in\n"
+            "no neighbor 192.0.2.1 route-map * out\n"
+            "no neighbor 192.0.2.1 maximum-prefix\n"
+            "no neighbor 192.0.2.1 activate\n"
+            "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
+            "no neighbor 192.0.2.1 send-community"
+        ),
     }
 
 
@@ -142,6 +150,14 @@ def test__generate_neighbor_part__minimal_ipv4_shutdown_different_local_as(mocke
             "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
             "no neighbor 192.0.2.1 send-community"
         ),
+        "L2VPN_EVPN": (
+            "no neighbor 192.0.2.1 route-map * in\n"
+            "no neighbor 192.0.2.1 route-map * out\n"
+            "no neighbor 192.0.2.1 maximum-prefix\n"
+            "no neighbor 192.0.2.1 activate\n"
+            "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
+            "no neighbor 192.0.2.1 send-community"
+        ),
     }
 
 
@@ -204,6 +220,14 @@ def test__generate_neighbor_part__minimal_ipv6(mocker):
             "no neighbor 2001:db8::1 send-community"
         ),
         "IPV6_UNICAST": (
+            "no neighbor 2001:db8::1 route-map * in\n"
+            "no neighbor 2001:db8::1 route-map * out\n"
+            "no neighbor 2001:db8::1 maximum-prefix\n"
+            "no neighbor 2001:db8::1 activate\n"
+            "no neighbor 2001:db8::1 soft-reconfiguration inbound\n"
+            "no neighbor 2001:db8::1 send-community"
+        ),
+        "L2VPN_EVPN": (
             "no neighbor 2001:db8::1 route-map * in\n"
             "no neighbor 2001:db8::1 route-map * out\n"
             "no neighbor 2001:db8::1 maximum-prefix\n"
@@ -289,6 +313,14 @@ def test__generate_neighbor_part__full(mocker):
             "neighbor 192.0.2.1 soft-reconfiguration inbound\n"
             "neighbor 192.0.2.1 send-community"
         ),
+        "L2VPN_EVPN": (
+            "no neighbor 192.0.2.1 route-map * in\n"
+            "no neighbor 192.0.2.1 route-map * out\n"
+            "no neighbor 192.0.2.1 maximum-prefix\n"
+            "no neighbor 192.0.2.1 activate\n"
+            "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
+            "no neighbor 192.0.2.1 send-community"
+        ),
     }
 
 
@@ -367,5 +399,13 @@ def test__generate_neighbor_part__delay_open_timer(mocker):
             "neighbor 192.0.2.1 activate\n"
             "neighbor 192.0.2.1 soft-reconfiguration inbound\n"
             "neighbor 192.0.2.1 send-community"
+        ),
+        "L2VPN_EVPN": (
+            "no neighbor 192.0.2.1 route-map * in\n"
+            "no neighbor 192.0.2.1 route-map * out\n"
+            "no neighbor 192.0.2.1 maximum-prefix\n"
+            "no neighbor 192.0.2.1 activate\n"
+            "no neighbor 192.0.2.1 soft-reconfiguration inbound\n"
+            "no neighbor 192.0.2.1 send-community"
         ),
     }

--- a/tests/states/openconfig_bgp/peer-groups/test_openconfig_bgp_peer_groups_sonic.py
+++ b/tests/states/openconfig_bgp/peer-groups/test_openconfig_bgp_peer_groups_sonic.py
@@ -38,6 +38,12 @@ def test__generate_peer_group_part__minimal(mocker):
             "neighbor RA02.01:PG-TOR send-community"
 
         ),
+        "L2VPN_EVPN": (
+            "no neighbor RA02.01:PG-TOR route-map * in\n"
+            "no neighbor RA02.01:PG-TOR route-map * out\n"
+            "no neighbor RA02.01:PG-TOR maximum-prefix\n"
+            "neighbor RA02.01:PG-TOR send-community"
+        ),
     }
 
 
@@ -69,6 +75,12 @@ def test__generate_peer_group_part__simple(mocker):
             "neighbor RA02.01:PG-TOR send-community"
         ),
         "IPV6_UNICAST": (
+            "neighbor RA02.01:PG-TOR route-map RM-LAN-IN in\n"
+            "neighbor RA02.01:PG-TOR route-map RM-LAN-OUT out\n"
+            "no neighbor RA02.01:PG-TOR maximum-prefix\n"
+            "neighbor RA02.01:PG-TOR send-community"
+        ),
+        "L2VPN_EVPN": (
             "neighbor RA02.01:PG-TOR route-map RM-LAN-IN in\n"
             "neighbor RA02.01:PG-TOR route-map RM-LAN-OUT out\n"
             "no neighbor RA02.01:PG-TOR maximum-prefix\n"
@@ -113,6 +125,12 @@ def test__generate_peer_group_part_with_safi(mocker):
             "neighbor RA02.01:PG-TOR send-community"
         ),
         "IPV6_UNICAST": (
+            "neighbor RA02.01:PG-TOR route-map RM-LAN-IN in\n"
+            "neighbor RA02.01:PG-TOR route-map RM-LAN-OUT out\n"
+            "no neighbor RA02.01:PG-TOR maximum-prefix\n"
+            "neighbor RA02.01:PG-TOR send-community"
+        ),
+        "L2VPN_EVPN": (
             "neighbor RA02.01:PG-TOR route-map RM-LAN-IN in\n"
             "neighbor RA02.01:PG-TOR route-map RM-LAN-OUT out\n"
             "no neighbor RA02.01:PG-TOR maximum-prefix\n"


### PR DESCRIPTION
Before this commit, L2VPN family was missing in the bgp configuration.